### PR TITLE
Created customizable ComputingNodesGenerator + small fixes

### DIFF
--- a/PureEdgeSim/com/mechalikh/pureedgesim/datacentersmanager/AbstractNode.java
+++ b/PureEdgeSim/com/mechalikh/pureedgesim/datacentersmanager/AbstractNode.java
@@ -40,7 +40,7 @@ public abstract class AbstractNode extends SimEntity implements ComputingNode {
 	 * The type of this node, whether a cloud data center, an edge data center, or
 	 * an edge/IoT device.
 	 * 
-	 * @see com.mechalikh.pureedgesim.datacentersmanager.ComputingNodesGenerator#generateDatacentersAndDevices()
+	 * @see com.mechalikh.pureedgesim.datacentersmanager.DefaultComputingNodesGenerator#generateDatacentersAndDevices()
 	 */
 	protected SimulationParameters.TYPES nodeType;
 
@@ -185,7 +185,7 @@ public abstract class AbstractNode extends SimEntity implements ComputingNode {
 	/**
 	 * Whether this computing node generates tasks (e.g. an IoT sensor).
 	 * 
-	 * @see ComputingNodesGenerator#generateEdgeDevices()
+	 * @see com.mechalikh.pureedgesim.datacentersmanager.DefaultComputingNodesGenerator#generateEdgeDevices()
 	 */
 	public void enableTaskGeneration(boolean generateTasks) {
 		this.isGeneratingTasks = generateTasks;
@@ -195,7 +195,7 @@ public abstract class AbstractNode extends SimEntity implements ComputingNode {
 	 * @return isGeneratingTasks: If this computing node generates tasks (e.g. an
 	 *         IoT sensor), or not.
 	 * 
-	 * @see ComputingNodesGenerator#generateEdgeDevices()
+	 * @see com.mechalikh.pureedgesim.datacentersmanager.DefaultComputingNodesGenerator#generateEdgeDevices()
 	 */
 	public boolean isGeneratingTasks() {
 		return this.isGeneratingTasks;

--- a/PureEdgeSim/com/mechalikh/pureedgesim/datacentersmanager/ComputingNode.java
+++ b/PureEdgeSim/com/mechalikh/pureedgesim/datacentersmanager/ComputingNode.java
@@ -146,7 +146,7 @@ public interface ComputingNode {
 	 * only when the type of this node is
 	 * {@link SimulationParameters.TYPES#EDGE_DEVICE}.
 	 * 
-	 * @see ComputingNodesGenerator#generateEdgeDevices()
+	 * @see com.mechalikh.pureedgesim.datacentersmanager.DefaultComputingNodesGenerator#generateEdgeDevices()
 	 * @see #isGeneratingTasks()
 	 * 
 	 * @param generateTasks true when this edge device can generate tasks, false
@@ -162,7 +162,7 @@ public interface ComputingNode {
 	 * @return whether this computing node generates tasks (e.g. an IoT sensor), or
 	 *         not.
 	 * 
-	 * @see ComputingNodesGenerator#generateEdgeDevices()
+	 * @see com.mechalikh.pureedgesim.datacentersmanager.DefaultComputingNodesGenerator#generateEdgeDevices()
 	 * @see #enableTaskGeneration(boolean)
 	 */
 	boolean isGeneratingTasks();

--- a/PureEdgeSim/com/mechalikh/pureedgesim/datacentersmanager/ComputingNodesGenerator.java
+++ b/PureEdgeSim/com/mechalikh/pureedgesim/datacentersmanager/ComputingNodesGenerator.java
@@ -20,26 +20,11 @@
  **/
 package com.mechalikh.pureedgesim.datacentersmanager;
 
-import java.io.FileInputStream;
-import java.io.InputStream;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
 import java.util.ArrayList;
-import java.util.List; 
-import java.util.Random;
+import java.util.List;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-
-import org.w3c.dom.Document;
 import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
 
-import com.mechalikh.pureedgesim.energy.EnergyModelComputingNode;
-import com.mechalikh.pureedgesim.locationmanager.Location;
 import com.mechalikh.pureedgesim.locationmanager.MobilityModel;
 import com.mechalikh.pureedgesim.scenariomanager.SimulationParameters;
 import com.mechalikh.pureedgesim.scenariomanager.SimulationParameters.TYPES;
@@ -54,14 +39,14 @@ import com.mechalikh.pureedgesim.taskgenerator.Task;
  * @author Charafeddine Mechalikh
  * @since PureEdgeSim 1.0
  */
-public class ComputingNodesGenerator {
+public abstract class ComputingNodesGenerator {
 
 	/**
 	 * The list that contains all orchestrators. It is used by the computing
 	 * node. In this case, the tasks are sent over the network to one of the
 	 * orchestrators to make decisions.
 	 * 
-	 * @see #generateDataCenters(String, TYPES)
+	 * @see com.mechalikh.pureedgesim.datacentersmanager.DefaultComputingNodesGenerator#generateDataCenters(String, TYPES)
 	 * @see com.mechalikh.pureedgesim.simulationmanager.DefaultSimulationManager#sendTaskToOrchestrator(Task)
 	 */
 	protected List<ComputingNode> orchestratorsList;
@@ -189,259 +174,8 @@ public class ComputingNodesGenerator {
 	 * Generates all computing nodes, including the Cloud data centers, the edge
 	 * ones, and the edge devices.
 	 */
-	public void generateDatacentersAndDevices() {
-
-		// Generate Edge and Cloud data centers.
-		generateDataCenters(SimulationParameters.cloudDataCentersFile, SimulationParameters.TYPES.CLOUD); 
-
-		generateDataCenters(SimulationParameters.edgeDataCentersFile, SimulationParameters.TYPES.EDGE_DATACENTER); 
-
-		// Generate edge devices.
-		generateEdgeDevices();
-
-		getSimulationManager().getSimulationLogger()
-				.print("%s - Datacenters and devices were generated", getClass().getSimpleName());
-
-	}
-
-	/**
-	 * Generates edge devices
-	 */
-	public void generateEdgeDevices() {
-
-		// Generate edge devices instances from edge devices types in xml file.
-		try (InputStream devicesFile = new FileInputStream(SimulationParameters.edgeDevicesFile)) {
-
-			DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-
-			// Disable access to external entities in XML parsing, by disallowing DocType
-			// declaration
-			dbFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-			DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
-			Document doc = dBuilder.parse(devicesFile);
-			NodeList nodeList = doc.getElementsByTagName("device");
-			Element edgeElement = null;
-
-			// Load all devices types in edge_devices.xml file.
-			for (int i = 0; i < nodeList.getLength(); i++) {
-				Node edgeNode = nodeList.item(i);
-				edgeElement = (Element) edgeNode;
-				generateDevicesInstances(edgeElement);
-			}
-
-			// if percentage of generated devices is < 100%.
-			if (mistOnlyList.size() < getSimulationManager().getScenario().getDevicesCount())
-				getSimulationManager().getSimulationLogger().print("%s - Wrong percentages values (the sum is inferior than 100%), check edge_devices.xml file !", getClass().getSimpleName());
-			// Add more devices.
-			if (edgeElement != null) {
-				int missingInstances = getSimulationManager().getScenario().getDevicesCount() - mistOnlyList.size();
-				for (int k = 0; k < missingInstances; k++) {
-					ComputingNode newDevice = createComputingNode(edgeElement, SimulationParameters.TYPES.EDGE_DEVICE);
-					insertEdgeDevice(newDevice);
-				}
-			}
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
-
-	}
-
-	/**
-	 * Puts the newly generated edge device in corresponding lists.
-	 */
-	protected void insertEdgeDevice(ComputingNode newDevice) {
-		mistOnlyList.add(newDevice);
-		allNodesList.add(newDevice);
-		if (!newDevice.isSensor()) {
-			mistOnlyListSensorsExcluded.add(newDevice);
-			mistAndCloudListSensorsExcluded.add(newDevice);
-			mistAndEdgeListSensorsExcluded.add(newDevice);
-			allNodesListSensorsExcluded.add(newDevice);
-		}
-	}
-
-	/**
-	 * Generates the required number of instances for each type of edge devices.
-	 * 
-	 * @param type The type of edge devices.
-	 */
-	protected void generateDevicesInstances(Element type) {
-
-		int instancesPercentage = Integer.parseInt(type.getElementsByTagName("percentage").item(0).getTextContent());
-
-		// Find the number of instances of this type of devices
-		int devicesInstances = getSimulationManager().getScenario().getDevicesCount() * instancesPercentage / 100;
-
-		for (int j = 0; j < devicesInstances; j++) {
-			if (mistOnlyList.size() > getSimulationManager().getScenario().getDevicesCount()) {
-				getSimulationManager().getSimulationLogger().print("%s - Wrong percentages values (the sum is superior than 100%), check edge_devices.xml file !",getClass().getSimpleName());
-				break;
-			}
-
-			try {
-				insertEdgeDevice(createComputingNode(type, SimulationParameters.TYPES.EDGE_DEVICE));
-			} catch (NoSuchAlgorithmException | NoSuchMethodException | SecurityException | InstantiationException
-					| IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
-				e.printStackTrace();
-			}
-
-		}
-	}
-
-	/**
-	 * Generates the Cloud and Edge data centers.
-	 * 
-	 * @param file The configuration file.
-	 * @param type The type, whether a CLOUD data center or an EDGE one.
-	 */
-	protected void generateDataCenters(String file, TYPES type) {
-
-		// Fill list with edge data centers
-		try (InputStream serversFile = new FileInputStream(file)) {
-			DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-
-			// Disable access to external entities in XML parsing, by disallowing DocType
-			// declaration
-			dbFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-			DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
-			Document doc = dBuilder.parse(serversFile);
-			NodeList datacenterList = doc.getElementsByTagName("datacenter");
-			for (int i = 0; i < datacenterList.getLength(); i++) {
-				Element datacenterElement = (Element) datacenterList.item(i);
-				ComputingNode computingNode = createComputingNode(datacenterElement, type);
-				if (computingNode.getType() == TYPES.CLOUD) {
-					cloudOnlyList.add(computingNode);
-					mistAndCloudListSensorsExcluded.add(computingNode);
-					if (SimulationParameters.enableOrchestrators
-							&& SimulationParameters.deployOrchestrators == "CLOUD") {
-						orchestratorsList.add(computingNode);
-					}
-				} else {
-					edgeOnlyList.add(computingNode);
-					mistAndEdgeListSensorsExcluded.add(computingNode);
-					if (SimulationParameters.enableOrchestrators
-							&& SimulationParameters.deployOrchestrators == "EDGE") {
-						orchestratorsList.add(computingNode);
-					}
-				}
-				allNodesList.add(computingNode);
-				allNodesListSensorsExcluded.add(computingNode);
-				edgeAndCloudList.add(computingNode);
-			}
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
-	}
-
-	/**
-	 * Creates the computing nodes.
-	 * 
-	 * @see #generateDataCenters(String, TYPES)
-	 * @see #generateDevicesInstances(Element)
-	 * 
-	 * @param datacenterElement The configuration file.
-	 * @param type              The type, whether an MIST (edge) device, an EDGE
-	 *                          data center, or a CLOUD one.
-	 * @throws NoSuchAlgorithmException
-	 * @throws SecurityException
-	 * @throws NoSuchMethodException
-	 * @throws InvocationTargetException
-	 * @throws IllegalArgumentException
-	 * @throws IllegalAccessException
-	 * @throws InstantiationException
-	 */
-	protected ComputingNode createComputingNode(Element datacenterElement, SimulationParameters.TYPES type)
-			throws NoSuchAlgorithmException, NoSuchMethodException, SecurityException, InstantiationException,
-			IllegalAccessException, IllegalArgumentException, InvocationTargetException {
-		// SecureRandom is preferred to generate random values.
-		Random random = SecureRandom.getInstanceStrong();
-		Boolean mobile = false;
-		double speed = 0;
-		double minPauseDuration = 0;
-		double maxPauseDuration = 0;
-		double minMobilityDuration = 0;
-		double maxMobilityDuration = 0;
-		int xPosition = -1;
-		int yPosition = -1;
-		double idleConsumption = Double
-				.parseDouble(datacenterElement.getElementsByTagName("idleConsumption").item(0).getTextContent());
-		double maxConsumption = Double
-				.parseDouble(datacenterElement.getElementsByTagName("maxConsumption").item(0).getTextContent());
-		Location datacenterLocation = new Location(xPosition, yPosition);
-		int numOfCores = Integer.parseInt(datacenterElement.getElementsByTagName("cores").item(0).getTextContent());
-		double mips = Double.parseDouble(datacenterElement.getElementsByTagName("mips").item(0).getTextContent());
-		double storage = Double.parseDouble(datacenterElement.getElementsByTagName("storage").item(0).getTextContent());
-		double ram = Double.parseDouble(datacenterElement.getElementsByTagName("ram").item(0).getTextContent());
-
-		Constructor<?> datacenterConstructor = computingNodeClass.getConstructor(SimulationManager.class, double.class,
-				int.class, double.class, double.class);
-		ComputingNode computingNode = (ComputingNode) datacenterConstructor.newInstance(getSimulationManager(), mips,
-				numOfCores, storage, ram);
-
-		computingNode.setAsOrchestrator(Boolean
-				.parseBoolean(datacenterElement.getElementsByTagName("isOrchestrator").item(0).getTextContent()));
-
-		if (computingNode.isOrchestrator())
-			orchestratorsList.add(computingNode);
-
-		computingNode.setEnergyModel(new EnergyModelComputingNode(maxConsumption, idleConsumption));
-
-		if (type == SimulationParameters.TYPES.EDGE_DATACENTER) {
-			String name = datacenterElement.getAttribute("name");
-			computingNode.setName(name);
-			Element location = (Element) datacenterElement.getElementsByTagName("location").item(0);
-			xPosition = Integer.parseInt(location.getElementsByTagName("x_pos").item(0).getTextContent());
-			yPosition = Integer.parseInt(location.getElementsByTagName("y_pos").item(0).getTextContent());
-			datacenterLocation = new Location(xPosition, yPosition);
-
-			for (int i = 0; i < edgeOnlyList.size(); i++)
-				if (datacenterLocation.equals(edgeOnlyList.get(i).getMobilityModel().getCurrentLocation()))
-					throw new IllegalArgumentException(
-							" Each Edge Data Center must have a different location, check the \"edge_datacenters.xml\" file!");
-
-			computingNode.setPeriphery(
-					Boolean.parseBoolean(datacenterElement.getElementsByTagName("periphery").item(0).getTextContent()));
-
-		} else if (type == SimulationParameters.TYPES.EDGE_DEVICE) {
-			mobile = Boolean.parseBoolean(datacenterElement.getElementsByTagName("mobility").item(0).getTextContent());
-			speed = Double.parseDouble(datacenterElement.getElementsByTagName("speed").item(0).getTextContent());
-			minPauseDuration = Double
-					.parseDouble(datacenterElement.getElementsByTagName("minPauseDuration").item(0).getTextContent());
-			maxPauseDuration = Double
-					.parseDouble(datacenterElement.getElementsByTagName("maxPauseDuration").item(0).getTextContent());
-			minMobilityDuration = Double.parseDouble(
-					datacenterElement.getElementsByTagName("minMobilityDuration").item(0).getTextContent());
-			maxMobilityDuration = Double.parseDouble(
-					datacenterElement.getElementsByTagName("maxMobilityDuration").item(0).getTextContent());
-			computingNode.getEnergyModel().setBattery(
-					Boolean.parseBoolean(datacenterElement.getElementsByTagName("battery").item(0).getTextContent()));
-			computingNode.getEnergyModel().setBatteryCapacity(Double
-					.parseDouble(datacenterElement.getElementsByTagName("batteryCapacity").item(0).getTextContent()));
-			computingNode.getEnergyModel().setIntialBatteryPercentage(Double.parseDouble(
-					datacenterElement.getElementsByTagName("initialBatteryLevel").item(0).getTextContent()));
-			computingNode.getEnergyModel().setConnectivityType(
-					datacenterElement.getElementsByTagName("connectivity").item(0).getTextContent());
-			computingNode.enableTaskGeneration(Boolean
-					.parseBoolean(datacenterElement.getElementsByTagName("generateTasks").item(0).getTextContent()));
-			// Generate random location for edge devices
-			datacenterLocation = new Location(random.nextInt(SimulationParameters.simulationMapLength),
-					random.nextInt(SimulationParameters.simulationMapLength));
-			getSimulationManager().getSimulationLogger()
-					.deepLog("ComputingNodesGenerator- Edge device:" + mistOnlyList.size() + "    location: ( "
-							+ datacenterLocation.getXPos() + "," + datacenterLocation.getYPos() + " )");
-		}
-		computingNode.setType(type);
-		Constructor<?> mobilityConstructor = mobilityModelClass.getConstructor(SimulationManager.class, Location.class);
-		MobilityModel mobilityModel = ((MobilityModel) mobilityConstructor.newInstance(simulationManager,
-				datacenterLocation)).setMobile(mobile).setSpeed(speed).setMinPauseDuration(minPauseDuration)
-				.setMaxPauseDuration(maxPauseDuration).setMinMobilityDuration(minMobilityDuration)
-				.setMaxMobilityDuration(maxMobilityDuration);
-
-		computingNode.setMobilityModel(mobilityModel);
-
-		return computingNode;
-	}
-
+	public abstract void generateDatacentersAndDevices();
+	
 	/**
 	 * Returns the list containing computing nodes that have been selected as
 	 * orchestrators (i.e. to make offloading decisions).
@@ -464,7 +198,7 @@ public class ComputingNodesGenerator {
 	/**
 	 * Gets the list containing all generated computing nodes.
 	 * 
-	 * @see #generateDatacentersAndDevices()
+	 * @see com.mechalikh.pureedgesim.datacentersmanager.DefaultComputingNodesGenerator#generateDatacentersAndDevices()
 	 * 
 	 * @return the list containing all generated computing nodes.
 	 */
@@ -476,7 +210,7 @@ public class ComputingNodesGenerator {
 	 * Gets the list containing all generated edge devices including sensors
 	 * (i.e., devices with no computing resources).
 	 * 
-	 * @see #generateDevicesInstances(Element)
+	 * @see com.mechalikh.pureedgesim.datacentersmanager.DefaultComputingNodesGenerator#generateDevicesInstances(Element)
 	 * 
 	 * @return the list containing all edge devices including sensors.
 	 */
@@ -487,7 +221,7 @@ public class ComputingNodesGenerator {
 	/**
 	 * Gets the list containing all generated edge data centers / servers.
 	 * 
-	 * @see #generateDataCenters(String, TYPES)
+	 * @see com.mechalikh.pureedgesim.datacentersmanager.DefaultComputingNodesGenerator#generateDataCenters(String, TYPES)
 	 * 
 	 * @return the list containing all edge data centers and servers.
 	 */
@@ -498,7 +232,7 @@ public class ComputingNodesGenerator {
 	/**
 	 * Gets the list containing only cloud data centers.
 	 * 
-	 * @see #generateDataCenters(String, TYPES)
+	 * @see com.mechalikh.pureedgesim.datacentersmanager.DefaultComputingNodesGenerator#generateDataCenters(String, TYPES)
 	 * 
 	 * @return the list containing all generated cloud data centers.
 	 */
@@ -510,8 +244,8 @@ public class ComputingNodesGenerator {
 	 * Gets the list containing cloud data centers and edge devices (except
 	 * sensors).
 	 * 
-	 * @see #generateDataCenters(String, TYPES)
-	 * @see #generateDevicesInstances(Element)
+	 * @see com.mechalikh.pureedgesim.datacentersmanager.DefaultComputingNodesGenerator#generateDataCenters(String, TYPES)
+	 * @see com.mechalikh.pureedgesim.datacentersmanager.DefaultComputingNodesGenerator#generateDevicesInstances(Element)
 	 * 
 	 * @return the list containing cloud data centers and edge devices.
 	 */
@@ -522,7 +256,7 @@ public class ComputingNodesGenerator {
 	/**
 	 * Gets the list containing cloud and edge data centers.
 	 * 
-	 * @see #generateDataCenters(String, TYPES)
+	 * @see com.mechalikh.pureedgesim.datacentersmanager.DefaultComputingNodesGenerator#generateDataCenters(String, TYPES)
 	 * 
 	 * @return the list containing cloud and edge data centers.
 	 */
@@ -534,8 +268,8 @@ public class ComputingNodesGenerator {
 	 * Gets the list containing edge data centers and edge devices (except
 	 * sensors).
 	 * 
-	 * @see #generateDataCenters(String, TYPES)
-	 * @see #generateDevicesInstances(Element)
+	 * @see com.mechalikh.pureedgesim.datacentersmanager.DefaultComputingNodesGenerator#generateDataCenters(String, TYPES)
+	 * @see com.mechalikh.pureedgesim.datacentersmanager.DefaultComputingNodesGenerator#generateDevicesInstances(Element)
 	 * 
 	 * @return the list containing edge data centers and edge devices.
 	 */
@@ -547,7 +281,7 @@ public class ComputingNodesGenerator {
 	 * Gets the list containing all generated edge devices except sensors (i.e.,
 	 * devices with no computing resources).
 	 * 
-	 * @see #generateDevicesInstances(Element)
+	 * @see com.mechalikh.pureedgesim.datacentersmanager.DefaultComputingNodesGenerator#generateDevicesInstances(Element)
 	 * 
 	 * @return the list containing all edge devices except sensors.
 	 */
@@ -558,8 +292,8 @@ public class ComputingNodesGenerator {
 	/**
 	 * Gets the list containing all computing nodes (except sensors).
 	 * 
-	 * @see #generateDataCenters(String, TYPES)
-	 * @see #generateDevicesInstances(Element)
+	 * @see com.mechalikh.pureedgesim.datacentersmanager.DefaultComputingNodesGenerator#generateDataCenters(String, TYPES)
+	 * @see com.mechalikh.pureedgesim.datacentersmanager.DefaultComputingNodesGenerator#generateDevicesInstances(Element)
 	 * 
 	 * @return the list containing all data centers and devices except sensors.
 	 */

--- a/PureEdgeSim/com/mechalikh/pureedgesim/datacentersmanager/DataCentersManager.java
+++ b/PureEdgeSim/com/mechalikh/pureedgesim/datacentersmanager/DataCentersManager.java
@@ -20,7 +20,6 @@
  **/
 package com.mechalikh.pureedgesim.datacentersmanager;
 
-import java.lang.Class;
 import java.lang.reflect.Constructor;
 
 import com.mechalikh.pureedgesim.locationmanager.MobilityModel;

--- a/PureEdgeSim/com/mechalikh/pureedgesim/datacentersmanager/DefaultComputingNodesGenerator.java
+++ b/PureEdgeSim/com/mechalikh/pureedgesim/datacentersmanager/DefaultComputingNodesGenerator.java
@@ -1,0 +1,306 @@
+/**
+ *     PureEdgeSim:  A Simulation Framework for Performance Evaluation of Cloud, Edge and Mist Computing Environments 
+ *
+ *     This file is part of PureEdgeSim Project.
+ *
+ *     PureEdgeSim is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     PureEdgeSim is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with PureEdgeSim. If not, see <http://www.gnu.org/licenses/>.
+ *     
+ *     @author Charafeddine Mechalikh
+ **/
+package com.mechalikh.pureedgesim.datacentersmanager;
+
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom; 
+import java.util.Random;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import com.mechalikh.pureedgesim.energy.EnergyModelComputingNode;
+import com.mechalikh.pureedgesim.locationmanager.Location;
+import com.mechalikh.pureedgesim.locationmanager.MobilityModel;
+import com.mechalikh.pureedgesim.scenariomanager.SimulationParameters;
+import com.mechalikh.pureedgesim.scenariomanager.SimulationParameters.TYPES;
+import com.mechalikh.pureedgesim.simulationmanager.SimulationManager;
+
+public class DefaultComputingNodesGenerator extends ComputingNodesGenerator {
+
+	public DefaultComputingNodesGenerator(SimulationManager simulationManager,
+			Class<? extends MobilityModel> mobilityModelClass, Class<? extends ComputingNode> computingNodeClass) {
+		super(simulationManager, mobilityModelClass, computingNodeClass);
+	}
+	
+	@Override
+	public void generateDatacentersAndDevices() {
+
+		// Generate Edge and Cloud data centers.
+		generateDataCenters(SimulationParameters.cloudDataCentersFile, SimulationParameters.TYPES.CLOUD); 
+
+		generateDataCenters(SimulationParameters.edgeDataCentersFile, SimulationParameters.TYPES.EDGE_DATACENTER); 
+
+		// Generate edge devices.
+		generateEdgeDevices();
+
+		getSimulationManager().getSimulationLogger()
+				.print("%s - Datacenters and devices were generated", getClass().getSimpleName());
+
+	}
+
+	/**
+	 * Generates edge devices
+	 */
+	public void generateEdgeDevices() {
+		// Generate edge devices instances from edge devices types in xml file.
+		try (InputStream devicesFile = new FileInputStream(SimulationParameters.edgeDevicesFile)) {
+
+			DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+
+			// Disable access to external entities in XML parsing, by disallowing DocType
+			// declaration
+			dbFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+			DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+			Document doc = dBuilder.parse(devicesFile);
+			NodeList nodeList = doc.getElementsByTagName("device");
+			Element edgeElement = null;
+
+			// Load all devices types in edge_devices.xml file.
+			for (int i = 0; i < nodeList.getLength(); i++) {
+				Node edgeNode = nodeList.item(i);
+				edgeElement = (Element) edgeNode;
+				generateDevicesInstances(edgeElement);
+			}
+
+			// if percentage of generated devices is < 100%.
+			if (mistOnlyList.size() < getSimulationManager().getScenario().getDevicesCount())
+				getSimulationManager().getSimulationLogger().print("%s - Wrong percentages values (the sum is inferior than 100%), check edge_devices.xml file !", getClass().getSimpleName());
+			// Add more devices.
+			if (edgeElement != null) {
+				int missingInstances = getSimulationManager().getScenario().getDevicesCount() - mistOnlyList.size();
+				for (int k = 0; k < missingInstances; k++) {
+					ComputingNode newDevice = createComputingNode(edgeElement, SimulationParameters.TYPES.EDGE_DEVICE);
+					insertEdgeDevice(newDevice);
+				}
+			}
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+
+	}
+
+	/**
+	 * Puts the newly generated edge device in corresponding lists.
+	 */
+	protected void insertEdgeDevice(ComputingNode newDevice) {
+		mistOnlyList.add(newDevice);
+		allNodesList.add(newDevice);
+		if (!newDevice.isSensor()) {
+			mistOnlyListSensorsExcluded.add(newDevice);
+			mistAndCloudListSensorsExcluded.add(newDevice);
+			mistAndEdgeListSensorsExcluded.add(newDevice);
+			allNodesListSensorsExcluded.add(newDevice);
+		}
+	}
+	
+	/**
+	 * Generates the required number of instances for each type of edge devices.
+	 * 
+	 * @param type The type of edge devices.
+	 */
+	protected void generateDevicesInstances(Element type) {
+
+		int instancesPercentage = Integer.parseInt(type.getElementsByTagName("percentage").item(0).getTextContent());
+
+		// Find the number of instances of this type of devices
+		int devicesInstances = getSimulationManager().getScenario().getDevicesCount() * instancesPercentage / 100;
+
+		for (int j = 0; j < devicesInstances; j++) {
+			if (mistOnlyList.size() > getSimulationManager().getScenario().getDevicesCount()) {
+				getSimulationManager().getSimulationLogger().print("%s - Wrong percentages values (the sum is superior than 100%), check edge_devices.xml file !",getClass().getSimpleName());
+				break;
+			}
+
+			try {
+				insertEdgeDevice(createComputingNode(type, SimulationParameters.TYPES.EDGE_DEVICE));
+			} catch (NoSuchAlgorithmException | NoSuchMethodException | SecurityException | InstantiationException
+					| IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+				e.printStackTrace();
+			}
+
+		}
+	}
+	
+	/**
+	 * Generates the Cloud and Edge data centers.
+	 * 
+	 * @param file The configuration file.
+	 * @param type The type, whether a CLOUD data center or an EDGE one.
+	 */
+	protected void generateDataCenters(String file, TYPES type) {
+		// Fill list with edge data centers
+		try (InputStream serversFile = new FileInputStream(file)) {
+			DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+
+			// Disable access to external entities in XML parsing, by disallowing DocType
+			// declaration
+			dbFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+			DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+			Document doc = dBuilder.parse(serversFile);
+			NodeList datacenterList = doc.getElementsByTagName("datacenter");
+			for (int i = 0; i < datacenterList.getLength(); i++) {
+				Element datacenterElement = (Element) datacenterList.item(i);
+				ComputingNode computingNode = createComputingNode(datacenterElement, type);
+				if (computingNode.getType() == TYPES.CLOUD) {
+					cloudOnlyList.add(computingNode);
+					mistAndCloudListSensorsExcluded.add(computingNode);
+					if (SimulationParameters.enableOrchestrators
+							&& SimulationParameters.deployOrchestrators == "CLOUD") {
+						orchestratorsList.add(computingNode);
+					}
+				} else {
+					edgeOnlyList.add(computingNode);
+					mistAndEdgeListSensorsExcluded.add(computingNode);
+					if (SimulationParameters.enableOrchestrators
+							&& SimulationParameters.deployOrchestrators == "EDGE") {
+						orchestratorsList.add(computingNode);
+					}
+				}
+				allNodesList.add(computingNode);
+				allNodesListSensorsExcluded.add(computingNode);
+				edgeAndCloudList.add(computingNode);
+			}
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+
+	}
+	
+	/**
+	 * Creates the computing nodes.
+	 * 
+	 * @see #generateDataCenters(String, TYPES)
+	 * @see #generateDevicesInstances(Element)
+	 * 
+	 * @param datacenterElement The configuration file.
+	 * @param type              The type, whether an MIST (edge) device, an EDGE
+	 *                          data center, or a CLOUD one.
+	 * @throws NoSuchAlgorithmException
+	 * @throws SecurityException
+	 * @throws NoSuchMethodException
+	 * @throws InvocationTargetException
+	 * @throws IllegalArgumentException
+	 * @throws IllegalAccessException
+	 * @throws InstantiationException
+	 */
+	protected ComputingNode createComputingNode(Element datacenterElement, SimulationParameters.TYPES type)
+			throws NoSuchAlgorithmException, NoSuchMethodException, SecurityException, InstantiationException,
+			IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+		// SecureRandom is preferred to generate random values.
+		Random random = SecureRandom.getInstanceStrong();
+		Boolean mobile = false;
+		double speed = 0;
+		double minPauseDuration = 0;
+		double maxPauseDuration = 0;
+		double minMobilityDuration = 0;
+		double maxMobilityDuration = 0;
+		int xPosition = -1;
+		int yPosition = -1;
+		double idleConsumption = Double
+				.parseDouble(datacenterElement.getElementsByTagName("idleConsumption").item(0).getTextContent());
+		double maxConsumption = Double
+				.parseDouble(datacenterElement.getElementsByTagName("maxConsumption").item(0).getTextContent());
+		Location datacenterLocation = new Location(xPosition, yPosition);
+		int numOfCores = Integer.parseInt(datacenterElement.getElementsByTagName("cores").item(0).getTextContent());
+		double mips = Double.parseDouble(datacenterElement.getElementsByTagName("mips").item(0).getTextContent());
+		double storage = Double.parseDouble(datacenterElement.getElementsByTagName("storage").item(0).getTextContent());
+		double ram = Double.parseDouble(datacenterElement.getElementsByTagName("ram").item(0).getTextContent());
+
+		Constructor<?> datacenterConstructor = computingNodeClass.getConstructor(SimulationManager.class, double.class,
+				int.class, double.class, double.class);
+		ComputingNode computingNode = (ComputingNode) datacenterConstructor.newInstance(getSimulationManager(), mips,
+				numOfCores, storage, ram);
+
+		computingNode.setAsOrchestrator(Boolean
+				.parseBoolean(datacenterElement.getElementsByTagName("isOrchestrator").item(0).getTextContent()));
+
+		if (computingNode.isOrchestrator())
+			orchestratorsList.add(computingNode);
+
+		computingNode.setEnergyModel(new EnergyModelComputingNode(maxConsumption, idleConsumption));
+
+		if (type == SimulationParameters.TYPES.EDGE_DATACENTER) {
+			String name = datacenterElement.getAttribute("name");
+			computingNode.setName(name);
+			Element location = (Element) datacenterElement.getElementsByTagName("location").item(0);
+			xPosition = Integer.parseInt(location.getElementsByTagName("x_pos").item(0).getTextContent());
+			yPosition = Integer.parseInt(location.getElementsByTagName("y_pos").item(0).getTextContent());
+			datacenterLocation = new Location(xPosition, yPosition);
+
+			for (int i = 0; i < edgeOnlyList.size(); i++)
+				if (datacenterLocation.equals(edgeOnlyList.get(i).getMobilityModel().getCurrentLocation()))
+					throw new IllegalArgumentException(
+							" Each Edge Data Center must have a different location, check the \"edge_datacenters.xml\" file!");
+
+			computingNode.setPeriphery(
+					Boolean.parseBoolean(datacenterElement.getElementsByTagName("periphery").item(0).getTextContent()));
+
+		} else if (type == SimulationParameters.TYPES.EDGE_DEVICE) {
+			mobile = Boolean.parseBoolean(datacenterElement.getElementsByTagName("mobility").item(0).getTextContent());
+			speed = Double.parseDouble(datacenterElement.getElementsByTagName("speed").item(0).getTextContent());
+			minPauseDuration = Double
+					.parseDouble(datacenterElement.getElementsByTagName("minPauseDuration").item(0).getTextContent());
+			maxPauseDuration = Double
+					.parseDouble(datacenterElement.getElementsByTagName("maxPauseDuration").item(0).getTextContent());
+			minMobilityDuration = Double.parseDouble(
+					datacenterElement.getElementsByTagName("minMobilityDuration").item(0).getTextContent());
+			maxMobilityDuration = Double.parseDouble(
+					datacenterElement.getElementsByTagName("maxMobilityDuration").item(0).getTextContent());
+			computingNode.getEnergyModel().setBattery(
+					Boolean.parseBoolean(datacenterElement.getElementsByTagName("battery").item(0).getTextContent()));
+			computingNode.getEnergyModel().setBatteryCapacity(Double
+					.parseDouble(datacenterElement.getElementsByTagName("batteryCapacity").item(0).getTextContent()));
+			computingNode.getEnergyModel().setIntialBatteryPercentage(Double.parseDouble(
+					datacenterElement.getElementsByTagName("initialBatteryLevel").item(0).getTextContent()));
+			computingNode.getEnergyModel().setConnectivityType(
+					datacenterElement.getElementsByTagName("connectivity").item(0).getTextContent());
+			computingNode.enableTaskGeneration(Boolean
+					.parseBoolean(datacenterElement.getElementsByTagName("generateTasks").item(0).getTextContent()));
+			// Generate random location for edge devices
+			datacenterLocation = new Location(random.nextInt(SimulationParameters.simulationMapWidth),
+					random.nextInt(SimulationParameters.simulationMapLength));
+			getSimulationManager().getSimulationLogger()
+					.deepLog("DefaultComputingNodesGenerator- Edge device:" + mistOnlyList.size() + "    location: ( "
+							+ datacenterLocation.getXPos() + "," + datacenterLocation.getYPos() + " )");
+		}
+		computingNode.setType(type);
+		Constructor<?> mobilityConstructor = mobilityModelClass.getConstructor(SimulationManager.class, Location.class);
+		MobilityModel mobilityModel = ((MobilityModel) mobilityConstructor.newInstance(simulationManager,
+				datacenterLocation)).setMobile(mobile).setSpeed(speed).setMinPauseDuration(minPauseDuration)
+				.setMaxPauseDuration(maxPauseDuration).setMinMobilityDuration(minMobilityDuration)
+				.setMaxMobilityDuration(maxMobilityDuration);
+
+		computingNode.setMobilityModel(mobilityModel);
+
+		return computingNode;
+	}
+
+}

--- a/PureEdgeSim/com/mechalikh/pureedgesim/network/NetworkLink.java
+++ b/PureEdgeSim/com/mechalikh/pureedgesim/network/NetworkLink.java
@@ -174,7 +174,7 @@ public class NetworkLink extends SimEntity {
 		this.transferProgressList.remove(transfer);
 
 		// Add the network link latency to the task network delay
-		transfer.getTask().addActualNetworkTime(0);
+		transfer.getTask().addActualNetworkTime(latency);
 
 		// Remove the previous hop (data has been transferred one hop)
 		transfer.getVertexList().remove(0);

--- a/PureEdgeSim/com/mechalikh/pureedgesim/scenariomanager/SimulationParameters.java
+++ b/PureEdgeSim/com/mechalikh/pureedgesim/scenariomanager/SimulationParameters.java
@@ -187,7 +187,7 @@ public class SimulationParameters {
 	/**
 	 * The types of computing nodes.
 	 * 
-	 * @see com.mechalikh.pureedgesim.datacentersmanager.ComputingNodesGenerator#generateDatacentersAndDevices()
+	 * @see com.mechalikh.pureedgesim.datacentersmanager.DefaultComputingNodesGenerator#generateDatacentersAndDevices()
 	 * @see com.mechalikh.pureedgesim.datacentersmanager.ComputingNode#setType(TYPES)
 	 */
 	public enum TYPES {

--- a/PureEdgeSim/com/mechalikh/pureedgesim/simulationmanager/SimulationAbstract.java
+++ b/PureEdgeSim/com/mechalikh/pureedgesim/simulationmanager/SimulationAbstract.java
@@ -21,7 +21,9 @@
 package com.mechalikh.pureedgesim.simulationmanager;
 
 import com.mechalikh.pureedgesim.datacentersmanager.ComputingNode;
+import com.mechalikh.pureedgesim.datacentersmanager.ComputingNodesGenerator;
 import com.mechalikh.pureedgesim.datacentersmanager.DefaultComputingNode;
+import com.mechalikh.pureedgesim.datacentersmanager.DefaultComputingNodesGenerator;
 import com.mechalikh.pureedgesim.datacentersmanager.DefaultTopologyCreator;
 import com.mechalikh.pureedgesim.datacentersmanager.TopologyCreator;
 import com.mechalikh.pureedgesim.locationmanager.DefaultMobilityModel;
@@ -96,6 +98,13 @@ public abstract class SimulationAbstract {
 	protected Class<? extends TopologyCreator> topologyCreator = DefaultTopologyCreator.class;
 	
 	/**
+	 * The Computing Nodes Generator class that is used in the simulation.
+	 * 
+	 * @see #setCustomComputingNodesGenerator(Class)
+	 */
+	protected Class<? extends ComputingNodesGenerator> computingNodesGenerator = DefaultComputingNodesGenerator.class;
+	
+	/**
 	 * Allows to use a custom computing node class in the simulation. The class must
 	 * extend the {@link ComputingNode} provided by PureEdgeSim.
 	 * 
@@ -164,6 +173,16 @@ public abstract class SimulationAbstract {
 	 */
 	public void setCustomSimulationManager(Class<? extends SimulationManager> simulationManager) {
 		this.simulationManager = simulationManager;
+	}
+	
+	/**
+	 * Allows to use a custom computing nodes generator in the simulation. The class must extend
+	 * the {@link ComputingNodesGenerator} provided by PureEdgeSim.
+	 * 
+	 * @param computingNodesGenerator the custom computing nodes generator class to use.
+	 */
+	public void setCustomComputingNodesGenerator(Class<? extends ComputingNodesGenerator> computingNodesGenerator) {
+		this.computingNodesGenerator = computingNodesGenerator;
 	}
 
 	/**

--- a/PureEdgeSim/com/mechalikh/pureedgesim/simulationmanager/SimulationThread.java
+++ b/PureEdgeSim/com/mechalikh/pureedgesim/simulationmanager/SimulationThread.java
@@ -198,7 +198,7 @@ public class SimulationThread {
 		// Generate all data centers, servers, an devices
 		SimLog.println(this.getClass().getSimpleName() + " - Initializing the Datacenters Manager Module...");
 		new DataCentersManager(simulationManager, simulation.mobilityModel, simulation.computingNode,
-				simulation.topologyCreator);
+				simulation.computingNodesGenerator, simulation.topologyCreator);
 
 		// Generate tasks list
 		SimLog.println(this.getClass().getSimpleName() + " - Initializing the Task Generator...");


### PR DESCRIPTION
1. The ComputingNodesGenerator class is now customizable similarly to TopologyCreator, SimulationManager, etc., classes. I believe this is a useful modification that allows the simulator users to have more control in how the resources are generated, improving the extensibility of the simulator. For example, in my own use case, I needed to provide more information about the edge datacenters than is specified in the XML setting file, and the simplest way to do this was to add my own fields into the XML file and then handle the added fields in the generator. Further, in some use cases users may want to have more control over how the edge devices are initially placed on the simulation area
2. A couple small fixes:
- In NetworkLink.java file, line 177, zero is added to the task's network time. I changed this so that it adds the link's latency, which is evidently what should be added.
- When placing the edge devices in the computing node generator, both x and y coordinates are randomly drawn based on the simulation map length. I changed this so that the x coordinate is randomly drawn based on the simulation map width.